### PR TITLE
Fiks slik at tester kjører

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,12 +227,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
+++ b/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
@@ -57,12 +57,12 @@ public class OppfolgingsbrukerRepositoryTest {
     }
 
     @Test
-    public void skal_hente_brukere_som_er_endret_og_har_riktig_status() {
+    public void skal_hente_brukere_som_er_endret() {
         OppfolgingsbrukerRepository repository = new OppfolgingsbrukerRepository(LocalH2Database.getDb());
 
         List<Oppfolgingsbruker> brukere = repository.changesSinceLastCheckSql("12355", ZonedDateTime.now().minusDays(1));
 
-        assertEquals(3, brukere.size());
+        assertEquals(4, brukere.size());
     }
 
     @Test


### PR DESCRIPTION
Endre test som feilet pga endring i funkjsonalitet der filtrering på kvalifiseringsgruppe og formidlingsgruppe ble tatt bort.