### PR TITLE
Optimaliser republisering av endring på bruker

### DIFF
--- a/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
+++ b/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
@@ -2,7 +2,6 @@ package no.nav.veilarbarena.repository;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.common.types.identer.Fnr;
 import no.nav.veilarbarena.repository.entity.OppfolgingsbrukerEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -14,7 +13,6 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static no.nav.veilarbarena.utils.DatabaseUtils.toSqlStringArray;
@@ -64,12 +62,9 @@ public class OppfolgingsbrukerRepository {
         );
     }
 
-    public List<Fnr> hentUnikeBrukerePage(int offset, int pageSize) {
-        String sql = format("SELECT DISTINCT fodselsnr FROM OPPFOLGINGSBRUKER ORDER BY fodselsnr OFFSET %d ROWS FETCH NEXT %d ROWS ONLY", offset, pageSize);
-        return db.query(sql, (rs, rowNum) -> rs.getString("fodselsnr"))
-                .stream()
-                .map(Fnr::of)
-                .collect(Collectors.toList());
+    public List<OppfolgingsbrukerEntity> hentBrukerePage(int offset, int pageSize) {
+        String sql = format("SELECT * FROM OPPFOLGINGSBRUKER ORDER BY fodselsnr OFFSET %d ROWS FETCH NEXT %d ROWS ONLY", offset, pageSize);
+        return db.query(sql, OppfolgingsbrukerRepository::mapOppfolgingsbruker);
     }
 
     @SneakyThrows

--- a/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
+++ b/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
@@ -32,7 +32,7 @@ public class OppfolgingsbrukerRepositoryTest {
     }
 
     @Test
-    public void hentUnikeBrukerePage__skal_hente_page_med_unike_brukere() {
+    public void hentBrukerePage__skal_hente_page_med_brukere() {
         JdbcTemplate db = LocalH2Database.getDb();
         db.execute("DELETE FROM OPPFOLGINGSBRUKER");
 
@@ -46,14 +46,14 @@ public class OppfolgingsbrukerRepositoryTest {
         insertBruker(fnr1);
         insertBruker(fnr3);
 
-        List<Fnr> unikeBrukerePage1 = repository.hentUnikeBrukerePage(0, 1);
-        assertEquals(1, unikeBrukerePage1.size());
-        assertEquals(fnr1, unikeBrukerePage1.get(0));
+        List<OppfolgingsbrukerEntity> brukerePage1 = repository.hentBrukerePage(0, 1);
+        assertEquals(1, brukerePage1.size());
+        assertEquals(fnr1.get(), brukerePage1.get(0).getFodselsnr());
 
-        List<Fnr> unikeBrukerePage2 = repository.hentUnikeBrukerePage(1, 2);
-        assertEquals(2, unikeBrukerePage2.size());
-        assertEquals(fnr2, unikeBrukerePage2.get(0));
-        assertEquals(fnr3, unikeBrukerePage2.get(1));
+        List<OppfolgingsbrukerEntity> brukerePage2 = repository.hentBrukerePage(1, 2);
+        assertEquals(2, brukerePage2.size());
+        assertEquals(fnr2.get(), brukerePage2.get(0).getFodselsnr());
+        assertEquals(fnr3.get(), brukerePage2.get(1).getFodselsnr());
     }
 
     @Test


### PR DESCRIPTION
Hent alle brukere samtidig istedenfor å hente 1 og 1 basert på fnr