### PR TITLE
Bump common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <common.version>2.2022.01.14_09.11-1d258a7225ea</common.version>
+        <common.version>2.2022.02.18_14.38-8d8bb494bd41</common.version>
         <springfox.version>3.0.0</springfox.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <tjenestespesifikasjoner.version>1.2019.09.25-00.21-49b69f0625e0</tjenestespesifikasjoner.version>


### PR DESCRIPTION
Inneholder støtte for å hente fnr fra pid-claim på tokens fra ID-porten. Ikke brukt i denne appen direkte, men via audit logging i common som er forbedret.