### PR TITLE
Setter opp endepunkt for å hente personId for et fnr

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -63,6 +63,9 @@ spec:
         - application: veilarbvedtaksstotte
           namespace: pto
           cluster: dev-fss
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: dev-gcp
   vault:
     enabled: true
     paths:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -62,6 +62,9 @@ spec:
         - application: veilarbvedtaksstotte
           namespace: pto
           cluster: prod-fss
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: prod-gcp
   vault:
     enabled: true
     paths:

--- a/src/main/java/no/nav/veilarbarena/controller/OppfolgingsbrukerController.java
+++ b/src/main/java/no/nav/veilarbarena/controller/OppfolgingsbrukerController.java
@@ -7,11 +7,10 @@ import no.nav.veilarbarena.service.ArenaService;
 import no.nav.veilarbarena.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+
+import javax.ws.rs.QueryParam;
 
 @Slf4j
 @RestController
@@ -38,8 +37,8 @@ public class OppfolgingsbrukerController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
-    @GetMapping("/{fnr}/hentPersonId")
-    public String getPersonIdForOppfolgingsbruker(@PathVariable("fnr") Fnr fnr) {
+    @GetMapping("/hentPersonId")
+    public String getPersonIdForOppfolgingsbruker(@RequestParam("fnr") Fnr fnr) {
         authService.sjekkTilgang(fnr);
 
         return arenaService.hentOppfolgingsbrukerSinPersonId(fnr)

--- a/src/main/java/no/nav/veilarbarena/controller/OppfolgingsbrukerController.java
+++ b/src/main/java/no/nav/veilarbarena/controller/OppfolgingsbrukerController.java
@@ -42,7 +42,6 @@ public class OppfolgingsbrukerController {
         authService.sjekkTilgang(fnr);
 
         return arenaService.hentOppfolgingsbrukerSinPersonId(fnr)
-                .map(OppfolgingsbrukerDTO::fraOppfolgingsbrukerTilPersonId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/src/main/java/no/nav/veilarbarena/controller/OppfolgingsbrukerController.java
+++ b/src/main/java/no/nav/veilarbarena/controller/OppfolgingsbrukerController.java
@@ -38,4 +38,12 @@ public class OppfolgingsbrukerController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
+    @GetMapping("/{fnr}/hentPersonId")
+    public String getPersonIdForOppfolgingsbruker(@PathVariable("fnr") Fnr fnr) {
+        authService.sjekkTilgang(fnr);
+
+        return arenaService.hentOppfolgingsbrukerSinPersonId(fnr)
+                .map(OppfolgingsbrukerDTO::fraOppfolgingsbrukerTilPersonId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
 }

--- a/src/main/java/no/nav/veilarbarena/controller/response/OppfolgingsbrukerDTO.java
+++ b/src/main/java/no/nav/veilarbarena/controller/response/OppfolgingsbrukerDTO.java
@@ -41,5 +41,9 @@ public class OppfolgingsbrukerDTO {
                 .setDoed_fra_dato(bruker.getDoedFraDato());
     }
 
+    public static String fraOppfolgingsbrukerTilPersonId(OppfolgingsbrukerEntity bruker) {
+        return bruker.getPersonId();
+    }
+
 }
 

--- a/src/main/java/no/nav/veilarbarena/controller/response/OppfolgingsbrukerDTO.java
+++ b/src/main/java/no/nav/veilarbarena/controller/response/OppfolgingsbrukerDTO.java
@@ -40,10 +40,5 @@ public class OppfolgingsbrukerDTO {
                 .setEr_doed(bruker.getErDoed())
                 .setDoed_fra_dato(bruker.getDoedFraDato());
     }
-
-    public static String fraOppfolgingsbrukerTilPersonId(OppfolgingsbrukerEntity bruker) {
-        return bruker.getPersonId();
-    }
-
 }
 

--- a/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
+++ b/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
@@ -35,6 +35,12 @@ public class OppfolgingsbrukerRepository {
         return brukere.isEmpty() ? Optional.empty() : Optional.of(brukere.get(0));
     }
 
+    public Optional<OppfolgingsbrukerEntity> hentOppfolgingsbrukerSinPersonId(String fnr){
+        String sql = "SELECT person_id FROM OPPFOLGINGSBRUKER WHERE fodselsnr = ?";
+        List<OppfolgingsbrukerEntity> brukere = db.query(sql, OppfolgingsbrukerRepository::mapOppfolgingsbrukerSinPersonId, fnr);
+        return brukere.isEmpty() ? Optional.empty() : Optional.of(brukere.get(0));
+    }
+
     public List<OppfolgingsbrukerEntity> hentOppfolgingsbrukere(List<String> fnrs) {
         if (fnrs.isEmpty()) {
             return Collections.emptyList();
@@ -86,6 +92,12 @@ public class OppfolgingsbrukerRepository {
                 .setErDoed(convertStringToBoolean(rs.getString("er_doed")))
                 .setDoedFraDato(convertTimestampToZonedDateTimeIfPresent(rs.getTimestamp("doed_fra_dato")))
                 .setTimestamp(convertTimestampToZonedDateTimeIfPresent(rs.getTimestamp("tidsstempel")));
+    }
+
+    @SneakyThrows
+    private static OppfolgingsbrukerEntity mapOppfolgingsbrukerSinPersonId(ResultSet rs, int row) {
+        return new OppfolgingsbrukerEntity()
+                .setPersonId(rs.getString("person_id"));
     }
 
     private static boolean convertStringToBoolean(String flag){

--- a/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
+++ b/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
@@ -35,10 +35,9 @@ public class OppfolgingsbrukerRepository {
         return brukere.isEmpty() ? Optional.empty() : Optional.of(brukere.get(0));
     }
 
-    public Optional<OppfolgingsbrukerEntity> hentOppfolgingsbrukerSinPersonId(String fnr){
+    public Optional<String> hentOppfolgingsbrukerSinPersonId(String fnr){
         String sql = "SELECT person_id FROM OPPFOLGINGSBRUKER WHERE fodselsnr = ?";
-        List<OppfolgingsbrukerEntity> brukere = db.query(sql, OppfolgingsbrukerRepository::mapOppfolgingsbrukerSinPersonId, fnr);
-        return brukere.isEmpty() ? Optional.empty() : Optional.of(brukere.get(0));
+        return Optional.ofNullable(db.queryForObject(sql, String.class, fnr));
     }
 
     public List<OppfolgingsbrukerEntity> hentOppfolgingsbrukere(List<String> fnrs) {
@@ -92,12 +91,6 @@ public class OppfolgingsbrukerRepository {
                 .setErDoed(convertStringToBoolean(rs.getString("er_doed")))
                 .setDoedFraDato(convertTimestampToZonedDateTimeIfPresent(rs.getTimestamp("doed_fra_dato")))
                 .setTimestamp(convertTimestampToZonedDateTimeIfPresent(rs.getTimestamp("tidsstempel")));
-    }
-
-    @SneakyThrows
-    private static OppfolgingsbrukerEntity mapOppfolgingsbrukerSinPersonId(ResultSet rs, int row) {
-        return new OppfolgingsbrukerEntity()
-                .setPersonId(rs.getString("person_id"));
     }
 
     private static boolean convertStringToBoolean(String flag){

--- a/src/main/java/no/nav/veilarbarena/repository/entity/OppfolgingsbrukerEntity.java
+++ b/src/main/java/no/nav/veilarbarena/repository/entity/OppfolgingsbrukerEntity.java
@@ -24,6 +24,5 @@ public class OppfolgingsbrukerEntity {
     Boolean erDoed;
     ZonedDateTime doedFraDato;
     ZonedDateTime timestamp; // Når brukeren sist ble endret
-    String personId;
 }
 

--- a/src/main/java/no/nav/veilarbarena/repository/entity/OppfolgingsbrukerEntity.java
+++ b/src/main/java/no/nav/veilarbarena/repository/entity/OppfolgingsbrukerEntity.java
@@ -24,5 +24,6 @@ public class OppfolgingsbrukerEntity {
     Boolean erDoed;
     ZonedDateTime doedFraDato;
     ZonedDateTime timestamp; // Når brukeren sist ble endret
+    String personId;
 }
 

--- a/src/main/java/no/nav/veilarbarena/service/ArenaService.java
+++ b/src/main/java/no/nav/veilarbarena/service/ArenaService.java
@@ -74,7 +74,7 @@ public class ArenaService {
         return oppfolgingsbrukerRepository.hentOppfolgingsbruker(fnr.get());
     }
 
-    public Optional<OppfolgingsbrukerEntity> hentOppfolgingsbrukerSinPersonId(Fnr fnr) {
+    public Optional<String> hentOppfolgingsbrukerSinPersonId(Fnr fnr) {
         return oppfolgingsbrukerRepository.hentOppfolgingsbrukerSinPersonId(fnr.get());
     }
 

--- a/src/main/java/no/nav/veilarbarena/service/ArenaService.java
+++ b/src/main/java/no/nav/veilarbarena/service/ArenaService.java
@@ -74,6 +74,10 @@ public class ArenaService {
         return oppfolgingsbrukerRepository.hentOppfolgingsbruker(fnr.get());
     }
 
+    public Optional<OppfolgingsbrukerEntity> hentOppfolgingsbrukerSinPersonId(Fnr fnr) {
+        return oppfolgingsbrukerRepository.hentOppfolgingsbrukerSinPersonId(fnr.get());
+    }
+
     public Optional<ArenaOppfolgingsstatusDTO> hentArenaOppfolgingsstatus(Fnr fnr) {
         return arenaOrdsClient.hentArenaOppfolgingsstatus(fnr);
     }

--- a/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
+++ b/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
@@ -68,10 +68,10 @@ public class OppfolgingsbrukerRepositoryTest {
     public void skal_hente_brukers_personId() {
         OppfolgingsbrukerRepository repository = new OppfolgingsbrukerRepository(LocalH2Database.getDb());
 
-        Optional<OppfolgingsbrukerEntity> bruker = repository.hentOppfolgingsbrukerSinPersonId("12345678900");
+        Optional<String> personId = repository.hentOppfolgingsbrukerSinPersonId("12345678900");
 
-        assertTrue(bruker.isPresent());
-        assertEquals("1", bruker.get().getPersonId());
+        assertTrue(personId.isPresent());
+        assertEquals("1", personId.get());
     }
 
     @Test

--- a/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
+++ b/src/test/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepositoryTest.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 import java.util.Random;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class OppfolgingsbrukerRepositoryTest {
 
@@ -63,6 +62,16 @@ public class OppfolgingsbrukerRepositoryTest {
         Optional<OppfolgingsbrukerEntity> bruker = repository.hentOppfolgingsbruker("12345678900");
 
         assertTrue(bruker.isPresent());
+    }
+
+    @Test
+    public void skal_hente_brukers_personId() {
+        OppfolgingsbrukerRepository repository = new OppfolgingsbrukerRepository(LocalH2Database.getDb());
+
+        Optional<OppfolgingsbrukerEntity> bruker = repository.hentOppfolgingsbrukerSinPersonId("12345678900");
+
+        assertTrue(bruker.isPresent());
+        assertEquals("1", bruker.get().getPersonId());
     }
 
     @Test


### PR DESCRIPTION
Jeg kjenner ikke noe til veilarbarena så jeg har gått etter utgangspunktet _Hva finnes fra før og kan vi gjøre noe lignende i koden for å hente ut personId_-tankegangen. Er derfor helt åpen for diskusjon av løsning om dere som forvalter løsningen har forslag til forbedringer.

Jeg har utført følgende i denne PRen:
* Opprettet et eget endepunkt `/api/oppfolgingsbruker/{fnr}/hentPersonId`
* Har opprettet egne metoder for uthenting fra database, istedenfor å benytte eksisterende metoder for oppfølgingsbruker. Årsaken var fordi vi kun er interessert i personId'en og ikke trenger alt _det andre_.