### PR TITLE
Whitelist paw-proxy i dev og prod

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -73,6 +73,9 @@ spec:
         - application: poao-tilgang
           namespace: poao
           cluster: dev-fss
+        - application: paw-proxy
+          namespace: paw
+          cluster: dev-fss
   vault:
     enabled: true
     paths:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -72,6 +72,9 @@ spec:
         - application: poao-tilgang
           namespace: poao
           cluster: prod-fss
+        - application: paw-proxy
+          namespace: paw
+          cluster: prod-fss
   vault:
     enabled: true
     paths:


### PR DESCRIPTION
paw-proxy proxyer kall fra veilarbregistrering i gcp. Trenger derfor inbound-regel for denne