### PR TITLE
Inbound regel for veilarbregistrering i gcp

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -55,6 +55,9 @@ spec:
         - application: veilarbregistrering
           namespace: paw
           cluster: dev-fss
+        - application: veilarbregistrering
+          namespace: paw
+          cluster: dev-gcp
         - application: veilarboppfolging
           namespace: pto
           cluster: dev-fss
@@ -72,9 +75,6 @@ spec:
           cluster: dev-gcp
         - application: poao-tilgang
           namespace: poao
-          cluster: dev-fss
-        - application: paw-proxy
-          namespace: paw
           cluster: dev-fss
   vault:
     enabled: true

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -72,9 +72,6 @@ spec:
         - application: poao-tilgang
           namespace: poao
           cluster: prod-fss
-        - application: paw-proxy
-          namespace: paw
-          cluster: prod-fss
   vault:
     enabled: true
     paths:


### PR DESCRIPTION
Veilarbarena har nå fått pub-ingress, så vi kan kalle den direkte fra veilarbregistrering i gcp og trenger ikke gå via paw-proxy

(Appen i prod-gcp eksisterer ikke enda, så jeg lager egen PR for den senere)