### PR TITLE
f Legger til egen clientId for veilarbregistrering i GCP

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -99,5 +99,7 @@ spec:
       value: dd1086a6-9b1d-4d7e-914e-3d868fb068a7
     - name: VEILARBREGISTRERING_CLIENT_ID
       value: 687bb3b0-a83c-47b7-9562-c6f9fedcc898
+    - name: VEILARBREGISTRERING_CLIENT_ID_GCP
+      value: 8da37db8-6021-4e08-81b3-99045e2c1704
     - name: TILTAKSGJENNOMFORING_API_CLIENT_ID
       value: 98a17237-0bfc-496e-ba28-cdb320960257

--- a/src/main/java/no/nav/veilarbarena/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/veilarbarena/config/EnvironmentProperties.java
@@ -37,6 +37,8 @@ public class EnvironmentProperties {
 
     private String veilarbregistreringClientId;
 
+    private String veilarbregistreringClientIdGCP;
+
     private String naisStsDiscoveryUrl;
 
     private String abacUrl;

--- a/src/main/java/no/nav/veilarbarena/controller/ArenaController.java
+++ b/src/main/java/no/nav/veilarbarena/controller/ArenaController.java
@@ -46,7 +46,8 @@ public class ArenaController {
             authService.sjekkAtSystembrukerErWhitelistet(
                     environmentProperties.getAmtTiltakClientId(),
                     environmentProperties.getTiltaksgjennomforingApiClientId(),
-                    environmentProperties.getVeilarbregistreringClientId()
+                    environmentProperties.getVeilarbregistreringClientId(),
+                    environmentProperties.getVeilarbregistreringClientIdGCP()
             );
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,6 +38,7 @@ app.env.poaoGcpProxyClientId=${POAO_GCP_PROXY_CLIENT_ID:null}
 app.env.tiltaksgjennomforingApiClientId=${TILTAKSGJENNOMFORING_API_CLIENT_ID:null}
 app.env.amtTiltakClientId=${AMT_TILTAK_CLIENT_ID:null}
 app.env.veilarbregistreringClientId=${VEILARBREGISTRERING_CLIENT_ID:null}
+app.env.veilarbregistreringClientIdGCP=${VEILARBREGISTRERING_CLIENT_ID_GCP:null}
 
 app.kafka.brokersUrl=${KAFKA_BROKERS_URL}
 app.kafka.endringPaaOppfolgingBrukerOnPremTopic=${ENDRING_PAA_OPPFOELGINGSBRUKER_TOPIC}

--- a/src/test/java/no/nav/veilarbarena/controller/ArenaControllerTest.java
+++ b/src/test/java/no/nav/veilarbarena/controller/ArenaControllerTest.java
@@ -63,7 +63,7 @@ public class ArenaControllerTest {
 
         mockMvc.perform(get("/api/arena/status").queryParam("fnr", FNR.get()));
 
-        verify(authService, times(1)).sjekkAtSystembrukerErWhitelistet("amt-tiltak", null, null);
+        verify(authService, times(1)).sjekkAtSystembrukerErWhitelistet("amt-tiltak", null, null, null);
     }
 
     @Test


### PR DESCRIPTION
Ettersom vi i Team PAW har behov for å kalle veilarbarena fra både GCP og FSS i en overgangsperiode, trenger vi å utvide whitelistingen av systembrukere til å inkludere en egen clientId for veilarbregistrering som kommer fra GCP.

Når appen er flyttet til GCP, og FSS er fjernet, vil vi kunne rydde og fjerne den ekstra linja.

Legger foreløpig kun inn en verdi for DEV, da jeg ikke har clientId for PROD enda.