### PR TITLE
TC-579 Gi token-generator tilgang i dev

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -74,6 +74,9 @@ spec:
         - application: amt-person-service
           namespace: amt
           cluster: dev-gcp
+        - application: azure-token-generator
+          namespace: aura
+          cluster: dev-gcp
   vault:
     enabled: true
     paths:


### PR DESCRIPTION
Gir token-generator tilgang i dev slik at vi kan generere access-tokens on-demand.

Fra [NAIS-docen](https://doc.nais.io/security/auth/azure-ad/usage/#token-generator):

> In many cases, you want to locally develop and test against a secured API in the development environments. To do so, you need a [token](https://doc.nais.io/security/auth/concepts/#bearer-token) to access said API.