### PR TITLE
Legg til støtte for "sistEndretDato" uten å brekke konsumenter av V2

### DIFF
--- a/src/main/java/no/nav/veilarbarena/controller/response/OppfolgingsbrukerV3DTO.java
+++ b/src/main/java/no/nav/veilarbarena/controller/response/OppfolgingsbrukerV3DTO.java
@@ -1,0 +1,42 @@
+package no.nav.veilarbarena.controller.response;
+
+import no.nav.veilarbarena.repository.entity.OppfolgingsbrukerEntity;
+
+import java.time.ZonedDateTime;
+
+public record OppfolgingsbrukerV3DTO(
+        String fodselsnr,
+        String formidlingsgruppekode,
+        ZonedDateTime iservFraDato,
+        String navKontor,
+        String kvalifiseringsgruppekode,
+        String rettighetsgruppekode,
+        String hovedmaalkode,
+        String sikkerhetstiltakTypeKode,
+        String frKode,
+        Boolean harOppfolgingssak,
+        Boolean sperretAnsatt,
+        Boolean erDoed,
+        ZonedDateTime doedFraDato,
+        ZonedDateTime sistEndretDato
+) {
+
+    public static OppfolgingsbrukerV3DTO fraOppfolgingsbruker(OppfolgingsbrukerEntity bruker) {
+        return new OppfolgingsbrukerV3DTO(
+                bruker.getFodselsnr(),
+                bruker.getFormidlingsgruppekode(),
+                bruker.getIservFraDato(),
+                bruker.getNavKontor(),
+                bruker.getKvalifiseringsgruppekode(),
+                bruker.getRettighetsgruppekode(),
+                bruker.getHovedmaalkode(),
+                bruker.getSikkerhetstiltakTypeKode(),
+                bruker.getFrKode(),
+                bruker.getHarOppfolgingssak(),
+                bruker.getSperretAnsatt(),
+                bruker.getErDoed(),
+                bruker.getDoedFraDato(),
+                bruker.getTimestamp()
+        );
+    }
+}

--- a/src/main/java/no/nav/veilarbarena/controller/v3/OppfolgingsbrukerV3Controller.java
+++ b/src/main/java/no/nav/veilarbarena/controller/v3/OppfolgingsbrukerV3Controller.java
@@ -1,0 +1,38 @@
+package no.nav.veilarbarena.controller.v3;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.veilarbarena.client.ords.dto.PersonRequest;
+import no.nav.veilarbarena.controller.response.OppfolgingsbrukerV3DTO;
+import no.nav.veilarbarena.service.ArenaService;
+import no.nav.veilarbarena.service.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v3")
+public class OppfolgingsbrukerV3Controller {
+
+    private final ArenaService arenaService;
+    private final AuthService authService;
+
+    @Autowired
+    public OppfolgingsbrukerV3Controller(ArenaService arenaService, AuthService authService) {
+        this.arenaService = arenaService;
+        this.authService = authService;
+    }
+
+    @PostMapping("/hent-oppfolgingsbruker")
+    public OppfolgingsbrukerV3DTO getOppfolgingsbrukerV2(@RequestBody PersonRequest personRequest) {
+        authService.sjekkTilgang(personRequest.getFnr());
+
+        return arenaService.hentOppfolgingsbruker(personRequest.getFnr())
+                .map(OppfolgingsbrukerV3DTO::fraOppfolgingsbruker)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+}


### PR DESCRIPTION
Legger til støtte for `sistEndretDato` i responsen. For å unngå å potensielt brekke konsumenter av `/v2` så legger jeg dette på ny versjon av API-et (`/v3`).

I praksis er dette helt likt som `OppfolgingsbrukerV2Controller` med følgende endringer:
* endret fra `snake_case` til `camelCase`
* lagt til nytt felt `sistEndretDato`