### PR TITLE
Publiser nylig registrerte brukere på kafka

### DIFF
--- a/src/main/java/no/nav/veilarbarena/controller/v2/ArenaV2Controller.java
+++ b/src/main/java/no/nav/veilarbarena/controller/v2/ArenaV2Controller.java
@@ -120,7 +120,6 @@ public class ArenaV2Controller {
         authService.sjekkTilgang(personRequest.getFnr());
         RegistrerIkkeArbeidssokerDto registrert = arenaService.registrerIkkeArbeidssoker(personRequest.getFnr())
                 .orElse(RegistrerIkkeArbeidssokerDto.errorResult("Bruker ikke registrert"));
-<<<<<<< HEAD
         /*
         OK_REGISTRERT_I_ARENA,
         FNR_FINNES_IKKE,

--- a/src/main/java/no/nav/veilarbarena/controller/v2/ArenaV2Controller.java
+++ b/src/main/java/no/nav/veilarbarena/controller/v2/ArenaV2Controller.java
@@ -132,6 +132,7 @@ public class ArenaV2Controller {
             case OK_REGISTRERT_I_ARENA -> {
                     try {
                         arenaService.refreshMaterializedOppfolgingsBrukerView();
+                        log.info("Refeshet materialized view for oppfolgingsbruker");
                         var blePublisert = publiserOppfolgingsbrukerService.publiserOppfolgingsbruker(personRequest.getFnr().get());
                         if (!blePublisert) {
                             log.warn("Fant ingen oppfølgingsbruker å publisere på kafka");

--- a/src/main/java/no/nav/veilarbarena/controller/v2/ArenaV2Controller.java
+++ b/src/main/java/no/nav/veilarbarena/controller/v2/ArenaV2Controller.java
@@ -120,6 +120,7 @@ public class ArenaV2Controller {
         authService.sjekkTilgang(personRequest.getFnr());
         RegistrerIkkeArbeidssokerDto registrert = arenaService.registrerIkkeArbeidssoker(personRequest.getFnr())
                 .orElse(RegistrerIkkeArbeidssokerDto.errorResult("Bruker ikke registrert"));
+<<<<<<< HEAD
         /*
         OK_REGISTRERT_I_ARENA,
         FNR_FINNES_IKKE,
@@ -132,7 +133,10 @@ public class ArenaV2Controller {
             case OK_REGISTRERT_I_ARENA -> {
                     try {
                         arenaService.refreshMaterializedOppfolgingsBrukerView();
-                        publiserOppfolgingsbrukerService.publiserOppfolgingsbruker(personRequest.getFnr().get());
+                        var blePublisert = publiserOppfolgingsbrukerService.publiserOppfolgingsbruker(personRequest.getFnr().get());
+                        if (!blePublisert) {
+                            log.warn("Fant ingen oppfølgingsbruker å publisere på kafka");
+                        }
                     } catch (Exception e) {
                         /* Skal fortsatt svare med OK, endringer vil propagert via OppfolgingsbrukerEndretSchedule istedet */
                         log.warn("Kunne ikke publisere nylig registrert oppfolgingsbruker på kafka", e);

--- a/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
+++ b/src/main/java/no/nav/veilarbarena/repository/OppfolgingsbrukerRepository.java
@@ -72,6 +72,14 @@ public class OppfolgingsbrukerRepository {
         return db.query(sql, OppfolgingsbrukerRepository::mapOppfolgingsbruker);
     }
 
+    public void refreshMaterializedOppfolgingsBrukerView() {
+        String sql = """
+        BEGIN
+            DBMS_MVIEW.REFRESH('OPPFOLGINGSBRUKER', '?');
+        END;""";
+        db.execute(sql);
+    }
+
     @SneakyThrows
     private static OppfolgingsbrukerEntity mapOppfolgingsbruker(ResultSet rs, int row) {
         return new OppfolgingsbrukerEntity()

--- a/src/main/java/no/nav/veilarbarena/service/ArenaService.java
+++ b/src/main/java/no/nav/veilarbarena/service/ArenaService.java
@@ -85,6 +85,10 @@ public class ArenaService {
         return oppfolgingsbrukerRepository.hentOppfolgingsbrukerSinPersonId(fnr.get());
     }
 
+    public void refreshMaterializedOppfolgingsBrukerView() {
+        return oppfolgingsbrukerRepository.refreshMaterializedOppfolgingsBrukerView();
+    }
+
     public Optional<ArenaOppfolgingsstatusDTO> hentArenaOppfolgingsstatus(Fnr fnr) {
         return arenaOrdsClient.hentArenaOppfolgingsstatus(fnr);
     }

--- a/src/main/java/no/nav/veilarbarena/service/ArenaService.java
+++ b/src/main/java/no/nav/veilarbarena/service/ArenaService.java
@@ -86,7 +86,7 @@ public class ArenaService {
     }
 
     public void refreshMaterializedOppfolgingsBrukerView() {
-        return oppfolgingsbrukerRepository.refreshMaterializedOppfolgingsBrukerView();
+        oppfolgingsbrukerRepository.refreshMaterializedOppfolgingsBrukerView();
     }
 
     public Optional<ArenaOppfolgingsstatusDTO> hentArenaOppfolgingsstatus(Fnr fnr) {

--- a/src/main/java/no/nav/veilarbarena/service/PubliserOppfolgingsbrukerService.java
+++ b/src/main/java/no/nav/veilarbarena/service/PubliserOppfolgingsbrukerService.java
@@ -1,0 +1,31 @@
+package no.nav.veilarbarena.service;
+
+import no.nav.veilarbarena.repository.OppfolgingsbrukerRepository;
+import no.nav.veilarbarena.repository.entity.OppfolgingsbrukerEntity;
+import no.nav.veilarbarena.utils.DtoMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PubliserOppfolgingsbrukerService {
+    private final OppfolgingsbrukerRepository oppfolgingsbrukerRepository;
+    private final KafkaProducerService kafkaProducerService;
+
+    public PubliserOppfolgingsbrukerService(
+        OppfolgingsbrukerRepository oppfolgingsbrukerRepository,
+        KafkaProducerService kafkaProducerService
+    ) {
+        this.oppfolgingsbrukerRepository = oppfolgingsbrukerRepository;
+        this.kafkaProducerService = kafkaProducerService;
+    }
+
+    public void publiserOppfolgingsbruker(String fnr) {
+        oppfolgingsbrukerRepository
+                .hentOppfolgingsbruker(fnr)
+                .ifPresent(this::publiserPaKafka);
+    }
+
+    private void publiserPaKafka(OppfolgingsbrukerEntity bruker) {
+        var endringPaBrukerV2 = DtoMapper.tilEndringPaaOppfoelgingsBrukerV2(bruker);
+        kafkaProducerService.publiserEndringPaOppfolgingsbrukerV2(endringPaBrukerV2);
+    }
+}

--- a/src/main/java/no/nav/veilarbarena/service/PubliserOppfolgingsbrukerService.java
+++ b/src/main/java/no/nav/veilarbarena/service/PubliserOppfolgingsbrukerService.java
@@ -18,10 +18,14 @@ public class PubliserOppfolgingsbrukerService {
         this.kafkaProducerService = kafkaProducerService;
     }
 
-    public void publiserOppfolgingsbruker(String fnr) {
-        oppfolgingsbrukerRepository
-                .hentOppfolgingsbruker(fnr)
-                .ifPresent(this::publiserPaKafka);
+    public Boolean publiserOppfolgingsbruker(String fnr) {
+        var bruker = oppfolgingsbrukerRepository.hentOppfolgingsbruker(fnr);
+        if (bruker.isPresent()) {
+            publiserPaKafka(bruker.get());
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private void publiserPaKafka(OppfolgingsbrukerEntity bruker) {

--- a/src/test/java/no/nav/veilarbarena/controller/v2/ArenaV2ControllerTest.java
+++ b/src/test/java/no/nav/veilarbarena/controller/v2/ArenaV2ControllerTest.java
@@ -9,6 +9,7 @@ import no.nav.veilarbarena.config.EnvironmentProperties;
 import no.nav.veilarbarena.controller.response.ArenaStatusDTO;
 import no.nav.veilarbarena.service.ArenaService;
 import no.nav.veilarbarena.service.AuthService;
+import no.nav.veilarbarena.service.PubliserOppfolgingsbrukerService;
 import no.nav.veilarbarena.utils.TestUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,8 @@ class ArenaV2ControllerTest {
     @MockBean
     private ArenaService arenaService;
 
+    @MockBean
+    private PubliserOppfolgingsbrukerService publiserOppfolgingsbrukerService;
 
 
     @Test


### PR DESCRIPTION
Publiser nylig registrert brukere via `/registrer-i-arena` endepunkt på oppfolgingsbruker-topic synkront hvis bruker ble registrert. Nå fanges de opp av en scheduled-job som kjører hvert 10 sek men trenger ikke vente på den