### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -49,6 +49,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   accessPolicy:
     outbound:
       rules:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -47,6 +47,10 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: java
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   accessPolicy:
     outbound:
       rules:


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.